### PR TITLE
Make document field required

### DIFF
--- a/app/views/properties/property_documents/_upload_document.html.erb
+++ b/app/views/properties/property_documents/_upload_document.html.erb
@@ -15,7 +15,7 @@
         <% #= form_tag upload_property_documents_path(@property) do |form| %>
           <div class="custom-file mb-sm-2">
             <% #= file_field_tag :documents, multiple: true, class: 'custom-file-input' %>
-            <%= form.file_field :documents, multiple: true, class: 'custom-file-input' %>
+            <%= form.file_field :documents, multiple: true, class: 'custom-file-input', required: true %>
             <label class="custom-file-label" for="property_documents">Choose file...</label>
           </div>
 


### PR DESCRIPTION
#58 

# Problem
Whenever a user submits the `upload_document` form without a file, an empty form is passed to the server, resulting in a server error.

# Proposal

This commit adds the HTML 5 tag "required" to the `document_field`, preventing the user from submitting an empty `upload_document` form.

## Screenshots

![image](https://user-images.githubusercontent.com/1649281/60450640-ed2ab980-9bef-11e9-942b-9e1c3d6691b3.png)
