### PR TITLE
Use Dockerfile caching to speed up builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,24 @@
 # Use an official Ruby runtime as a parent image
 FROM ruby:2.5.1
+LABEL maintainer="Hebron George <hebrontgeorge@gmail.com>"
+# Run server when the container launches
+CMD puma -C config/puma.rb
+ENTRYPOINT ["bin/entrypoint.sh"]
+
+# Make port 3000 available to the world outside this container
+ENV PORT="3000" \
+    APP_DIR="/app/"
+EXPOSE $PORT
+RUN mkdir $APP_DIR
+WORKDIR $APP_DIR
+
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y libpq-dev nodejs jq
 
-# Set the working directory to /app
-RUN mkdir /app
-
-# Copy the current directory contents into the container at /app
-COPY . /app
-
-# Install any needed packages specified in Gemfile
-WORKDIR /app
+# Try doing the bundle stuff first
+COPY Gemfile Gemfile.lock $APP_DIR
 RUN bundle install --binstubs
 
-# Make port 3000 available to the world outside this container
-ENV PORT 3000
-EXPOSE $PORT
-ENTRYPOINT ["bin/entrypoint.sh"]
-
-LABEL maintainer="Hebron George <hebrontgeorge@gmail.com>"
-# Run server when the container launches
-CMD puma -C config/puma.rb
+# Copy the current directory contents into the container at /app
+COPY . $APP_DIR


### PR DESCRIPTION
# Problem

It feels as if whenever we need to run, `docker-compose build website` or
`docker-compose up --build`, Docker was taking forever to build the new image.

# Proposal

The `Dockerfile` was not taking advantage of caching done between layers. This
pull request reorganizes the `Dockerfile` layers from ones that are the most
static, to those that will probably change most over time.

## Examples

The following are timed examples on:

`Intel(R) Core(TM) i7-6600U CPU @ 2.60GHz @ 16 GB RAM`

```bash
➜  happy_house git:(master) ✗ time docker-compose build website

#### Building the first time

# Old Dockerfile
docker-compose build website  1.19s user 0.15s system 0% cpu 4:11.71 total

# New Dockerfile
docker-compose build website  1.13s user 0.13s system 0% cpu 4:08.71 total

# Adding 'sidekiq-cron'
# Old Dockerfile
docker-compose build website  0.56s user 0.07s system 0% cpu 1:55.92 total

# New Dockerfile
docker-compose build website  0.54s user 0.07s system 0% cpu 1:46.27 total
```
