### PR TITLE
chore: require aws-sdk-s3 when bundle install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "mini_magick", "~> 4.8"
 gem "bootsnap", ">= 1.1.0", require: false
 
 # For Amazon S3 storage
-gem "aws-sdk-s3", require: false
+gem "aws-sdk-s3"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console


### PR DESCRIPTION
This was causing an issue where AWS SDK components were missing, resulting in us not being able to properly start-up a Rails console.

From the bundler.io page:

  Specify :require => false to prevent bundler from requiring the gem, but still install it and maintain dependencies.

  @see https://bundler.io/guides/gemfile.html