### PR TITLE
Polish: drop redundant mini_magick declaration (Step 7)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,9 +31,6 @@ gem "jbuilder", "~> 2.5"
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
-# Use ActiveStorage variant
-gem "mini_magick", "~> 4.8"
-
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -398,7 +398,6 @@ DEPENDENCIES
   importmap-rails
   jbuilder (~> 2.5)
   listen (~> 3.9)
-  mini_magick (~> 4.8)
   observer
   pg (~> 1.1)
   pry-rails


### PR DESCRIPTION
- Remove the direct `gem "mini_magick"` (unused directly; image_processing still pulls it in transitively for Active Storage variants, and the app uses the :vips processor). No behavior change.
- Confirmed no stale webpacker/turbolinks/yarn/coffee/jquery/wicked_pdf/ sentry references remain outside intentional explanatory comments.

Final verification on Rails 8.1.3: 268 examples / 0 failures, zeitwerk:check clean, production assets:precompile succeeds, dev/test/ production boot.


Claude-Session: https://claude.ai/code/session_01SFFNgzqthg7aqG5MsPjLVY